### PR TITLE
fix: set lastScroll client-side to avoid SSR error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ function useDetectScroll(props: ScrollProps): Direction {
 
   const threshold = Math.max(0, thr);
   let ticking = false;
-  let lastScroll: number = axis === Axis.Y ? window.scrollY : window.scrollX;
+  let lastScroll = 0;
 
   /** Function to update scroll direction */
   const updateScrollDir = useCallback(() => {
@@ -86,6 +86,8 @@ function useDetectScroll(props: ScrollProps): Direction {
   }, [axis, threshold, scrollDown, scrollUp]);
 
   useEffect(() => {
+    lastScroll = axis === Axis.Y ? window.scrollY : window.scrollX;
+
     /** Function to handle onScroll event */
     const onScroll = () => {
       if (!ticking) {


### PR DESCRIPTION
### Issue

The `useDetectScroll` hook uses the `window` object to set the initial value of `lastScroll`, which is not available during server-side rendering. In Next.js (or any other SSR framework) the result is a `ReferenceError: window is not defined` error.

### Solution

This initializes `lastScroll` to `0` and moves the `window` object reference inside the `useEffect` hook to ensure it's only accessed on the client-side, preventing the error.