### PR TITLE
feat: allow hook to accept no props with default settings

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -60,7 +60,7 @@ The `useDetectScroll` hook takes an options object that can include the followin
 To detect upward or downward scroll:
 
 ```js
-const scrollDir = useDetectScroll({});
+const scrollDir = useDetectScroll();
 
 // Returns: "up", "down", or "still"
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ type ScrollProps = {
  *
  * @returns {Direction} - The current direction of scrolling.
  */
-function useDetectScroll(props: ScrollProps): Direction {
+function useDetectScroll(props: ScrollProps = {}): Direction {
   const {
     thr = 0,
     axis = Axis.Y,


### PR DESCRIPTION
By adding a default assignment to `props`, it's no longer necessary to pass an empty object to `useDetectScroll` to use it with default options:

```ts
const scrollDir = useDetectScroll()
```